### PR TITLE
SLING-7241 Fix SciptEngineManager

### DIFF
--- a/src/main/java/org/apache/sling/pipes/PipeBindings.java
+++ b/src/main/java/org/apache/sling/pipes/PipeBindings.java
@@ -74,8 +74,16 @@ public class PipeBindings {
      * public constructor, built from pipe's resource
      * @param resource pipe's configuration resource
      */
-    public PipeBindings(Resource resource){
-        engine.setContext(scriptContext);
+    public PipeBindings(Resource resource) throws Exception {
+    	//In some contexts the nashorn engine cannot be obtained. Do fallback to system classloader.
+    	if(engine == null){
+    		engine = new ScriptEngineManager(null).getEngineByName("nashorn");
+    		//Check if nashorn can still not be instantiated
+    		if(engine == null){
+    			throw new Exception("Can not instantiate nashorn scriptengine. Check JVM version & capabilities.");
+    		}
+    	}
+    	engine.setContext(scriptContext);
         //add path bindings where path.MyPipe will give MyPipe current resource path
         getBindings().put(PATH_BINDING, pathBindings);
 

--- a/src/test/java/org/apache/sling/pipes/PipeBindingsTest.java
+++ b/src/test/java/org/apache/sling/pipes/PipeBindingsTest.java
@@ -45,13 +45,13 @@ public class PipeBindingsTest extends AbstractPipeTest {
         context.load().json("/container.json", PATH_PIPE);
     }
 
-    private PipeBindings getDummyTreeBinding(){
+    private PipeBindings getDummyTreeBinding() throws Exception{
         Resource resource = context.resourceResolver().getResource(PATH_PIPE + "/" + ContainerPipeTest.NN_DUMMYTREE);
         return new PipeBindings(resource);
     }
 
     @Test
-    public void testEvaluateSimpleString() throws ScriptException {
+    public void testEvaluateSimpleString() throws Exception {
         PipeBindings bindings = getDummyTreeBinding();
         String simple = "simple string";
         String evaluated = (String)bindings.evaluate(simple);
@@ -59,7 +59,7 @@ public class PipeBindingsTest extends AbstractPipeTest {
     }
 
     @Test
-    public void computeEcma5Expression() {
+    public void computeEcma5Expression() throws Exception {
         PipeBindings bindings = getDummyTreeBinding();
         Map<String,String> expressions = new HashMap<>();
         expressions.put("blah ${blah} blah", "'blah ' + blah + ' blah'");


### PR DESCRIPTION
Using this constructor instead of the empty one will return Nashorn engine even if not attached to system bundle. Detail & how to repoduce issue see SLING-7241