### PR TITLE
SLING-7616 Add jcr:uuid to ignored properties

### DIFF
--- a/src/main/java/org/apache/sling/pipes/BasePipe.java
+++ b/src/main/java/org/apache/sling/pipes/BasePipe.java
@@ -54,7 +54,7 @@ public class BasePipe implements Pipe {
     protected ReferencePipe referrer;
 
     // used by pipes using complex JCR configurations
-    public static final List<String> IGNORED_PROPERTIES = Arrays.asList(new String[]{"jcr:lastModified", "jcr:primaryType", "jcr:created", "jcr:createdBy"});
+    public static final List<String> IGNORED_PROPERTIES = Arrays.asList(new String[]{"jcr:lastModified", "jcr:primaryType", "jcr:created", "jcr:createdBy", "jcr:uuid"});
 
     protected Boolean dryRunObject;
 


### PR DESCRIPTION
Extend the ignored properties to allow creation of nodes which have jcr:uuid nodes (like thumbnail.png)