### PR TITLE
SLING-7793 ACLs pipe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <groupId>*</groupId>
             <artifactId>*</artifactId>
         </exclusion>
-    </exclusions>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -224,6 +224,12 @@
       <version>3.1.44</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-jcr-commons</artifactId>
+      <version>2.17.5</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -246,6 +252,12 @@
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
       <version>1.3.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+      <version>2.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/sling/pipes/PipeBuilder.java
+++ b/src/main/java/org/apache/sling/pipes/PipeBuilder.java
@@ -30,6 +30,7 @@ import org.apache.sling.pipes.internal.RemovePipe;
 import org.apache.sling.pipes.internal.TraversePipe;
 import org.apache.sling.pipes.internal.WritePipe;
 import org.apache.sling.pipes.internal.XPathPipe;
+import org.apache.sling.pipes.internal.ACLPipe;
 import org.apache.sling.pipes.internal.inputstream.CsvPipe;
 import org.apache.sling.pipes.internal.inputstream.JsonPipe;
 import org.apache.sling.pipes.internal.inputstream.RegexpPipe;
@@ -251,6 +252,35 @@ public interface PipeBuilder {
     @PipeExecutor(command = "mp", resourceType = MultiPropertyPipe.RESOURCE_TYPE, pipeClass = MultiPropertyPipe.class,
             description = "read multi property, and output each value in the bindings")
     PipeBuilder mp();
+
+    /**
+     * attach an ACL pipe to the current context
+     * @return updated instance of PipeBuilder
+     * @throws IllegalAccessException in case it's called with bad configuration
+     */
+    @PipeExecutor(command = "acls", resourceType = ACLPipe.RESOURCE_TYPE, pipeClass = ACLPipe.class,
+            description = "output each acls on the resource or  acls for authorizable in repository in bindings")
+    PipeBuilder acls() throws IllegalAccessException;
+
+    /**
+     * attach an ACL pipe to the current context and sets allow acls on the resource
+     * @param expr prinicipalName/AuthorizableId of the user to give allow privileges to
+     * @return updated instance of PipeBuilder
+     * @throws IllegalAccessException in case it's called with bad configuration
+     */
+    @PipeExecutor(command = "allow", resourceType = ACLPipe.RESOURCE_TYPE, pipeClass = ACLPipe.class,
+            description = "sets allow acls on the resource")
+    PipeBuilder allow(String expr) throws IllegalAccessException;
+
+    /**
+     * attach an ACL pipe to the current context and sets deny acls on the resource
+     * @param expr prinicipalName/AuthorizableId of the user/group to give deny privileges to
+     * @return updated instance of PipeBuilder
+     * @throws IllegalAccessException in case it's called with bad configuration
+     */
+    @PipeExecutor(command = "deny", resourceType = ACLPipe.RESOURCE_TYPE, pipeClass = ACLPipe.class,
+            description = "sets deny acls on the resource")
+    PipeBuilder deny(String expr) throws IllegalAccessException;
 
     /**
      * parameterized current pipe in the context

--- a/src/main/java/org/apache/sling/pipes/internal/ACLPipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/ACLPipe.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.pipes.internal;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
+import org.apache.jackrabbit.api.security.principal.PrincipalManager;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.pipes.BasePipe;
+import org.apache.sling.pipes.PipeBindings;
+import org.apache.sling.pipes.Plumber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.Privilege;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+import javax.script.ScriptException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class ACLPipe extends BasePipe {
+    private static Logger logger = LoggerFactory.getLogger(ACLPipe.class);
+    public static final String RESOURCE_TYPE = RT_PREFIX + "acl";
+    public static final String PN_USERNAME = "userName";
+    public static final String PN_ALLOW = "allow";
+    public static final String PN_DENY = "deny";
+    public static final String PN_AUTHORIZABLE = "authorizable";
+    public static final String PATH_KEY = "path";
+    public static final String PRIVILEGES_KEY = "rep:privileges";
+    public static final String ACE_GRANT_KEY = "rep:GrantACE";
+    public static final String ACE_DENY_KEY = "rep:DenyACE";
+    public static final String JCR_PRIVILEGES_INPUT = "jcr:privileges";
+    public static final String PRIVILEGES_JSON_KEY = "privileges";
+
+    Session session;
+    UserManager userManager;
+    Privilege[] privileges;
+    String[] privilegesInput;
+    boolean allow;
+    boolean deny;
+    Object outputBinding;
+
+    @Override
+    public Object getOutputBinding() {
+        if (outputBinding != null) {
+            return outputBinding;
+        }
+        return super.getOutputBinding();
+    }
+
+    @Override
+    public boolean modifiesContent() {
+        return allow || deny ;
+    }
+
+    /**
+     * public constructor
+     *
+     * @param plumber  plumber instance
+     * @param resource configuration resource
+     * @param upperBindings already set binding we want to initiate our pipe with
+     * @throws Exception bad configuration handling
+     */
+    public ACLPipe(Plumber plumber, Resource resource, PipeBindings upperBindings) throws Exception {
+        super(plumber, resource, upperBindings);
+        session = resolver.adaptTo(Session.class);
+        userManager = resolver.adaptTo(UserManager.class);
+        privilegesInput = properties.get(JCR_PRIVILEGES_INPUT, new String[]{});
+        allow = properties.get(PN_ALLOW, false);
+        deny = properties.get(PN_DENY, false);
+    }
+
+    @Override
+    public Iterator<Resource> computeOutput() throws Exception {
+        Resource resource = getInput();
+        if (resource != null) {
+            if (allow || deny) {
+                logger.debug("Going to changing ACL for the resource at path {}", resource.getPath());
+                if (StringUtils.isEmpty(getExpr())) {
+                    throw new IllegalArgumentException("expression for the principal or authorizable Id should be provided or provided correctly for privileges to be set");
+                }
+                Principal principal = getPrincipalFor(getExpr());
+                if (ArrayUtils.isEmpty(privilegesInput)) {
+                    // create a privilege set with jcr:all if allow or jcr:read if deny
+                    privileges = allow ? AccessControlUtils.privilegesFromNames(session, Privilege.JCR_ALL) : AccessControlUtils.privilegesFromNames(session, Privilege.JCR_READ);
+                }
+                else {
+                    privilegesInput = processPrivilegesInput(privilegesInput);
+                    privileges = AccessControlUtils.privilegesFromNames(session, privilegesInput);
+                }
+                addAccessControlEntry(resource, principal);
+                return super.computeOutput();
+            }
+            bindACLs(resource);
+            return super.computeOutput();
+        }
+        return EMPTY_ITERATOR;
+    }
+
+    /**
+     * Binds ACLs of the current resource to the bindings
+     * If current Resource is an Authorizable and authorizable flag is true then ACLs of the authorizablie on repository is put in bindings
+     * @param resource current resource
+     */
+
+    protected void bindACLs(Resource resource) {
+        try {
+            Authorizable auth = checkIsAuthorizableResource(resource);
+            if ( null != auth ) {
+                //get privileges for an auth on the repository , authorizable flag should be true if resource is an authorizable
+                bindAclsForAuthorizableResource(auth);
+                return;
+            }
+            logger.info("binding acls for resource at path {}", resource.getPath());
+            AccessControlList acl = AccessControlUtils.getAccessControlList(session, resource.getPath());
+            JackrabbitAccessControlEntry[] entries = (JackrabbitAccessControlEntry[]) acl.getAccessControlEntries();
+            JsonArrayBuilder principal_Privileges_Array = Json.createArrayBuilder();
+            for (JackrabbitAccessControlEntry entry : entries) {
+                JsonObjectBuilder principal_Privileges_Mappings = Json.createObjectBuilder();
+                JsonArrayBuilder privileges = Json.createArrayBuilder();
+                for ( Privilege privilege : entry.getPrivileges() ){
+                    privileges.add(privilege.getName());
+                }
+                principal_Privileges_Mappings.add(PN_AUTHORIZABLE, entry.getPrincipal().getName());
+                principal_Privileges_Mappings.add(PRIVILEGES_JSON_KEY, privileges);
+                if (entry.isAllow()) {
+                    principal_Privileges_Mappings.add(PN_ALLOW, true);
+                } else {
+                    principal_Privileges_Mappings.add(PN_DENY, true);
+                }
+                principal_Privileges_Array.add(principal_Privileges_Mappings);
+            }
+            outputBinding = JsonUtil.toString(principal_Privileges_Array);
+        } catch ( Exception e ) {
+            outputBinding = JsonUtil.toString(Json.createObjectBuilder());
+            logger.error("unable to bind acls", e);
+        }
+
+    }
+
+    /**
+     * Binds ACLs of an Authorizable on repository
+     * @param auth current resource as an authorizable
+     * @throws RepositoryException in case something goes wrong while executing xpath query
+     */
+
+    protected void bindAclsForAuthorizableResource(Authorizable auth) throws RepositoryException {
+        //query for searching in full repository where auth is prinicpal in access control entry.
+        logger.info("binding acls for authorizable {} and authID {}", auth.getPath(), auth.getID());
+        String query = "/jcr:root//element(*, rep:ACE)[@rep:principalName = '" + auth.getID() + "']";
+        Iterator<Resource> resources = resolver.findResources(query, javax.jcr.query.Query.XPATH);
+        JsonObjectBuilder authPermisions = Json.createObjectBuilder();
+        JsonArrayBuilder allowArray = Json.createArrayBuilder();
+        JsonArrayBuilder denyArray = Json.createArrayBuilder();
+        resources.forEachRemaining((res) -> {
+            String[] privileges = res.adaptTo(ValueMap.class).get(PRIVILEGES_KEY, String[].class);
+            JsonArrayBuilder privilegesArray = Json.createArrayBuilder();
+            for(String privilege: privileges){
+                privilegesArray.add(privilege);
+            }
+            JsonObjectBuilder ACEObject = Json.createObjectBuilder();
+            ACEObject.add(PATH_KEY, res.getParent().getParent().getPath());
+            ACEObject.add(PRIVILEGES_JSON_KEY, privilegesArray);
+            if (res.getResourceType().equals(ACE_GRANT_KEY) ){
+                allowArray.add(ACEObject);
+            }
+            else if (res.getResourceType().equals(ACE_DENY_KEY)) {
+                denyArray.add(ACEObject);
+            }
+        });
+        authPermisions.add(PN_AUTHORIZABLE, auth.getID());
+        authPermisions.add(PN_ALLOW, allowArray);
+        authPermisions.add(PN_DENY, denyArray);
+        outputBinding = JsonUtil.toString(authPermisions);
+    }
+
+    protected Authorizable checkIsAuthorizableResource(Resource resource) {
+        return resource.adaptTo(Authorizable.class);
+    }
+
+    /**
+     * get Principal for principal name set as an expression in the pipe
+     * @param prinicipalName for which the principal has to be found
+     * @return Principal for the principalName
+     */
+
+    protected Principal getPrincipalFor(String prinicipalName) {
+        Principal principal = null;
+        try {
+            if (StringUtils.isNotBlank(prinicipalName)) {
+                logger.debug("try to find principalId {}", prinicipalName);
+                JackrabbitSession jackrabbitSession = ( JackrabbitSession )session;
+                PrincipalManager principalManager = jackrabbitSession.getPrincipalManager();
+                principal = principalManager.getPrincipal(prinicipalName);
+            }
+        } catch (Exception e){
+            logger.error("unable to get principal for principalName {} ", prinicipalName, e);
+        }
+        return principal;
+    }
+
+    private void addAccessControlEntry(Resource resource, Principal principal) throws Exception{
+        logger.info("adding privileges {} for principal {} allow {} deny {} with dryRun {} ",ArrayUtils.toString(privileges), principal.getName(), allow, deny, isDryRun());
+        if (!isDryRun()) {
+            if (allow) {
+                AccessControlUtils.addAccessControlEntry(session, resource.getPath(), principal, this.privileges, true);
+            } else if (deny) {
+                AccessControlUtils.addAccessControlEntry(session, resource.getPath(), principal, this.privileges, false);
+            }
+        }
+    }
+
+    private String[] processPrivilegesInput(String[] privilegesInput) throws ScriptException {
+        String expr = bindings.instantiateExpression(ArrayUtils.toString(privilegesInput));
+        if ( expr.indexOf("[") > -1 && expr.indexOf("]") > -1) {
+            return Arrays.stream(expr.substring(expr.indexOf("[") + 1, expr.indexOf("]")).split(",")).map((s) -> s.trim()).toArray(size->new String[size]);
+        }
+        return privilegesInput;
+    }
+}

--- a/src/main/java/org/apache/sling/pipes/internal/PipeBuilderImpl.java
+++ b/src/main/java/org/apache/sling/pipes/internal/PipeBuilderImpl.java
@@ -244,6 +244,21 @@ public class PipeBuilderImpl implements PipeBuilder {
         return writeToCurrentStep(Pipe.NN_CONF, properties);
     }
 
+    @Override
+    public PipeBuilder acls() throws IllegalAccessException{
+        return pipe(ACLPipe.RESOURCE_TYPE);
+    }
+
+    @Override
+    public PipeBuilder allow(String expr) throws IllegalAccessException{
+        return pipeWithExpr(ACLPipe.RESOURCE_TYPE, expr).with("allow","true");
+    }
+
+    @Override
+    public PipeBuilder deny(String expr) throws IllegalAccessException{
+        return pipeWithExpr(ACLPipe.RESOURCE_TYPE, expr).with("deny","true");
+    }
+
     /**
      * Add some configurations to current's Step node defined by name (if null, will be step's properties)
      * @param name name of the configuration node, can be null in which case it's the subpipe itself

--- a/src/test/java/org/apache/sling/pipes/internal/ACLPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/ACLPipeTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.pipes.internal;
+
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
+import org.apache.jackrabbit.api.security.principal.PrincipalManager;
+import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.pipes.AbstractPipeTest;
+import org.apache.sling.pipes.Pipe;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.jcr.Session;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.Privilege;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+import java.security.Principal;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ACLPipeTest extends AbstractPipeTest {
+
+    @Rule
+    public SlingContext oak = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Before
+    public void setup() throws PersistenceException {
+        super.setup();
+        oak.load().json("/acl.json", PATH_PIPE);
+        oak.load().json("/SLING-INF/jcr_root/content/fruits.json", PATH_FRUITS);
+    }
+
+    @Test
+    public void testAllow() throws Exception{
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/allow"));
+        Iterator<Resource> outputs = pipe.getOutput();
+        JackrabbitAccessControlEntry[] entries = retrieveACLsSetOnResourceWithPipe(pipe);
+        assertNotNull(entries);
+        assertEquals("There should be only one entry", 1, entries.length);
+        assertEquals("Entry prinicipal should be anonymous", "anonymous", entries[0].getPrincipal().getName());
+        assertEquals("Entry should be allow or rep:GrantACE", true, entries[0].isAllow());
+        assertEquals("Entry privileges should be jcr:read", "jcr:read", entries[0].getPrivileges()[0].getName());
+    }
+
+    @Test
+    public void testAllowDefault() throws Exception{
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/allowDefault"));
+        Iterator<Resource> outputs = pipe.getOutput();
+        JackrabbitAccessControlEntry[] entries = retrieveACLsSetOnResourceWithPipe(pipe);assertNotNull(entries);
+        assertEquals("There should be only one entry", 1, entries.length);
+        assertEquals("Entry prinicipal should be anonymous", "anonymous", entries[0].getPrincipal().getName());
+        assertEquals("Entry should be allow or rep:GrantACE", true, entries[0].isAllow());
+        assertEquals("Entry privileges should be jcr:all by default", "jcr:all", entries[0].getPrivileges()[0].getName());
+    }
+
+    @Test
+    public void testDeny() throws Exception{
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/deny"));
+        Iterator<Resource> outputs = pipe.getOutput();
+        JackrabbitAccessControlEntry[] entries = retrieveACLsSetOnResourceWithPipe(pipe);
+        assertNotNull(entries);
+        assertEquals("There should be only one entry", 1, entries.length);
+        assertEquals("Entry prinicipal should be anonymous", "anonymous", entries[0].getPrincipal().getName());
+        assertEquals("Entry should be deny or rep:DenyACE", false, entries[0].isAllow());
+        assertEquals("Entry privileges should be jcr:write", "jcr:write", entries[0].getPrivileges()[0].getName());
+    }
+
+    @Test
+    public void testDenyDefault() throws Exception{
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/denyDefault"));
+        Iterator<Resource> outputs = pipe.getOutput();
+        JackrabbitAccessControlEntry[] entries = retrieveACLsSetOnResourceWithPipe(pipe);
+        assertNotNull(entries);
+        assertEquals("There should be only one entry", 1, entries.length);
+        assertEquals("Entry prinicipal should be anonymous", "anonymous", entries[0].getPrincipal().getName());
+        assertEquals("Entry should be deny or rep:DenyACE", false, entries[0].isAllow());
+        assertEquals("Entry privileges should be jcr:read by default", "jcr:read", entries[0].getPrivileges()[0].getName());
+    }
+
+    @Test
+    public void testACLs() throws Exception{
+        setACLsOnResourceWithPath(PATH_FRUITS);
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/acl"));
+        pipe.getOutput();
+        Object bindings = pipe.getOutputBinding();
+        assertNotNull(bindings);
+        JsonStructure json = JsonUtil.parse((String)bindings);
+        assertEquals(json.getValueType().name(), "ARRAY");
+        JsonArray jsonValues = JsonUtil.parseArray((String)bindings);
+        assertEquals("size should be one", 1, jsonValues.size());
+        assertEquals("values should be equal", jsonValues.getJsonObject(0).getString("authorizable"), "anonymous");
+        assertEquals("values should be equal", JsonUtil.toString(jsonValues.getJsonObject(0).get("privileges")), "[\"jcr:read\"]");
+    }
+
+    @Ignore
+    @Test
+    /*
+    Ignoring the test for now since Oak mocking doesn't support resolver.adapt(Authorizable.class)
+     */
+    public void testACLsWithResourceAsAuthorizable() throws Exception{
+        setACLsOnResourceWithPath(PATH_FRUITS);
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + "/aclAuthorizable"));
+        pipe.getOutput();
+        Object bindings = pipe.getOutputBinding();
+        JsonStructure json = JsonUtil.parse((String)bindings);
+        assertEquals(json.getValueType().name(), "OBJECT");
+        JsonObject jsonValues = JsonUtil.parseObject((String)bindings);
+        assertEquals("size should be one", 1, jsonValues.size());
+        assertEquals("values should be equal",  jsonValues.getJsonArray("allow").getJsonObject(0).getString("path"),"/content/fruits");
+        assertEquals("values should be equal", JsonUtil.toString(jsonValues.getJsonArray("allow").getJsonObject(0).getJsonArray("privileges")), "[\"jcr:read\"]");}
+
+    private void setACLsOnResourceWithPath(String path) throws Exception{
+        Session session = oak.resourceResolver().adaptTo(Session.class);
+        JackrabbitSession jackrabbitSession = ( JackrabbitSession ) session;
+        PrincipalManager principalManager = jackrabbitSession.getPrincipalManager();
+        Principal principal = principalManager.getPrincipal("anonymous");
+        Privilege[] privileges = AccessControlUtils.privilegesFromNames(session, Privilege.JCR_READ);
+        AccessControlUtils.addAccessControlEntry(oak.resourceResolver().adaptTo(Session.class), path, principal, privileges, true);
+    }
+
+    private JackrabbitAccessControlEntry[] retrieveACLsSetOnResourceWithPipe(Pipe pipe) throws Exception{
+        //retrieve acls on resource after setting
+        AccessControlList acl = AccessControlUtils.getAccessControlList(oak.resourceResolver().adaptTo(Session.class), pipe.getInput().getPath());
+        JackrabbitAccessControlEntry[] entries = (JackrabbitAccessControlEntry[]) acl.getAccessControlEntries();
+        return entries;
+    }
+}

--- a/src/test/resources/acl.json
+++ b/src/test/resources/acl.json
@@ -1,0 +1,43 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "allow": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/content/fruits",
+    "expr": "anonymous",
+    "jcr:privileges":["jcr:read"],
+    "allow":true
+  },
+  "deny": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/content/fruits",
+    "expr": "anonymous",
+    "jcr:privileges":["jcr:write"],
+    "deny":true
+  },
+  "allowDefault": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/content/fruits",
+    "expr": "anonymous",
+    "allow":true
+  },
+  "denyDefault": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/content/fruits",
+    "expr": "anonymous",
+    "deny":true
+  },
+  "acl": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/content/fruits"
+  },
+  "aclAuthorizable": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "slingPipes/acl",
+    "path":"/rep:security/rep:authorizables/rep:users/a/an/anonymous"
+  }
+}


### PR DESCRIPTION
ACLs pipe to set or retrieve acls on a resource , few example are given below.
**.allow(username/principalName/authorizableId)** (default allow jcr:all on currentResource to userName)
**.allow(username/principalName/authorizableId).with('jcr:privileges',[jcr:read,jcr:write])** sets given allow privileges on currentResource to userName).
**.deny(username/principalName/authorizableId)** (default deny jcr:read on currentResource to userName)
**.deny(username/principalName/authorizableId).with('jcr:privileges',[jcr:read,jcr:write])** sets given deny privileges on currentResource to userName).
**.acls()** will return current resource, with in output bindings array of ACLs mentioning principal, privilege of that resource.
**.acls()** If current resource is an authorizable, then returns ACLs attached to that user in the repository in bindings.

test case for current resource as an authorizable is marked as ignored since mocking for authorizable is getting failed.

@npeltier 

Raised this one as there were too many commits on https://github.com/apache/sling-org-apache-sling-pipes/pull/6