### PR TITLE
SLING-8648

### DIFF
--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -70,8 +70,6 @@ public class MovePipe extends BasePipe {
                     //if target item exist then either it should overwrite or order the source before the target
                     Resource parent = resolver.getResource(targetPath).getParent();
                     Node targetParent = session.getItem(targetPath).getParent();
-                    String targetPathNewNode = targetPath + UUID.randomUUID();
-                    String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
                     String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
                     if (orderBefore && !isDryRun()) {
                         logger.debug("ordering {} before {}", resource.getPath(), targetPath);
@@ -86,6 +84,8 @@ public class MovePipe extends BasePipe {
                         }
                     } else if (overwriteTarget && !isDryRun()) {
                         logger.debug("overwriting {}", targetPath);
+                        String targetPathNewNode = targetPath + UUID.randomUUID();
+                        String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
                         if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
                             session.move(resource.getPath(), targetPathNewNode);
                             targetParent.orderBefore(newNodeName, oldNodeName);

--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -17,6 +17,7 @@
 package org.apache.sling.pipes.internal;
 
 import org.apache.jackrabbit.api.JackrabbitNode;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.pipes.BasePipe;
@@ -68,38 +69,10 @@ public class MovePipe extends BasePipe {
                 Session session = resolver.adaptTo(Session.class);
                 if (session.itemExists(targetPath)) {
                     //if target item exist then either it should overwrite or order the source before the target
-                    Resource parent = resolver.getResource(targetPath).getParent();
-                    Node targetParent = session.getItem(targetPath).getParent();
-                    String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
                     if (orderBefore && !isDryRun()) {
-                        logger.debug("ordering {} before {}", resource.getPath(), targetPath);
-                        if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
-                            String targetNodeName = ResourceUtil.createUniqueChildName(parent, resource.getName());
-                            String targetNodePath = targetParent.getPath() + SLASH + targetNodeName;
-                            session.move(resource.getPath(), targetNodePath);
-                            targetParent.orderBefore(targetNodeName, oldNodeName);
-                            output = Collections.singleton(parent.getChild(targetNodeName)).iterator();
-                        } else {
-                            logger.warn("parent resource {} doesn't support ordering", parent.getPath());
-                        }
+                        output = reorder(resource, targetPath, session);
                     } else if (overwriteTarget && !isDryRun()) {
-                        logger.debug("overwriting {}", targetPath);
-                        String targetPathNewNode = targetPath + UUID.randomUUID();
-                        String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
-                        if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
-                            session.move(resource.getPath(), targetPathNewNode);
-                            targetParent.orderBefore(newNodeName, oldNodeName);
-                            session.removeItem(targetPath);
-                            // Need to use JackrabbitNode.rename() here, since session.move(targetPathNewNode, targetPath)
-                            // would move the new node back to the end of its siblings list
-                            JackrabbitNode newNode = (JackrabbitNode) session.getNode(targetPathNewNode);
-                            newNode.rename(oldNodeName);
-                            output = Collections.singleton(parent.getChild(oldNodeName)).iterator();
-                        } else {
-                            session.removeItem(targetPath);
-                            session.move(resource.getPath(), targetPath);
-                            output = Collections.singleton(parent.getChild(resource.getName())).iterator();
-                        }
+                        output = overwriteTargetNode(resource, targetPath, session);
                     } else {
                         logger.warn("{} already exists, nothing will be done here, nothing outputed");
                     }
@@ -134,5 +107,45 @@ public class MovePipe extends BasePipe {
             logger.warn("bad configuration of the pipe, will do nothing");
         }
         return output;
+    }
+
+    private Iterator<Resource> overwriteTargetNode(Resource resource, String targetPath, Session session) throws Exception {
+        logger.debug("overwriting {}", targetPath);
+        Resource parent = resolver.getResource(targetPath).getParent();
+        Node targetParent = session.getItem(targetPath).getParent();
+        String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
+        String targetPathNewNode = targetPath + UUID.randomUUID();
+        String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
+        if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
+            session.move(resource.getPath(), targetPathNewNode);
+            targetParent.orderBefore(newNodeName, oldNodeName);
+            session.removeItem(targetPath);
+            // Need to use JackrabbitNode.rename() here, since session.move(targetPathNewNode, targetPath)
+            // would move the new node back to the end of its siblings list
+            JackrabbitNode newNode = (JackrabbitNode) session.getNode(targetPathNewNode);
+            newNode.rename(oldNodeName);
+            return Collections.singleton(parent.getChild(oldNodeName)).iterator();
+        } else {
+            session.removeItem(targetPath);
+            session.move(resource.getPath(), targetPath);
+            return Collections.singleton(parent.getChild(resource.getName())).iterator();
+        }
+    }
+
+    private Iterator<Resource> reorder(Resource resource, String targetPath, Session session) throws Exception {
+        logger.debug("ordering {} before {}", resource.getPath(), targetPath);
+        Resource parent = resolver.getResource(targetPath).getParent();
+        Node targetParent = session.getItem(targetPath).getParent();
+        String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
+        if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
+            String targetNodeName = ResourceUtil.createUniqueChildName(parent, resource.getName());
+            String targetNodePath = targetParent.getPath() + SLASH + targetNodeName;
+            session.move(resource.getPath(), targetNodePath);
+            targetParent.orderBefore(targetNodeName, oldNodeName);
+            return Collections.singleton(parent.getChild(targetNodeName)).iterator();
+        } else {
+            logger.warn("parent resource {} doesn't support ordering", parent.getPath());
+        }
+        return EMPTY_ITERATOR;
     }
 }

--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -67,7 +67,7 @@ public class MovePipe extends BasePipe {
             try {
                 Session session = resolver.adaptTo(Session.class);
                 if (session.itemExists(targetPath)){
-                    if (overwriteTarget || orderBefore && !isDryRun()) {
+                    if ((overwriteTarget || orderBefore) && !isDryRun()) {
                         Resource target = resolver.getResource(targetPath);
                         Resource parent = target.getParent();
                         Node targetParent = session.getItem(targetPath).getParent();
@@ -95,9 +95,11 @@ public class MovePipe extends BasePipe {
                                 // would move the new node back to the end of its siblings list
                                 JackrabbitNode newNode = (JackrabbitNode) session.getNode(targetPathNewNode);
                                 newNode.rename(oldNodeName);
+                                output = Collections.singleton(parent.getChild(oldNodeName)).iterator();
                             } else {
                                 session.removeItem(targetPath);
                                 session.move(resource.getPath(), targetPath);
+                                output = Collections.singleton(parent.getChild(resource.getName())).iterator();
                             }
                         }
                     } else {

--- a/src/test/java/org/apache/sling/pipes/internal/MovePipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/MovePipeTest.java
@@ -34,11 +34,11 @@ public class MovePipeTest extends AbstractPipeTest {
 
     static final String MOVENODE_PIPE = "/moveNode";
     static final String MOVENODEOVERWRITE_PIPE = "/moveNodeOverwrite";
+    static final String MOVENODEORDER_PIPE = "/moveNodeOrder";
     static final String MOVEPROPERTY_PIPE = "/moveProperty";
     static final String APPLE_NODE_PATH = "/apple";
     static final String BANANA_NODE_PATH = "/banana";
     static final String MOVED_NODE_PATH = "/granny";
-    static final String MOVED_PROPERTY_PATH = "/indexFruits";
 
     @Before
     public void setup() throws PersistenceException {
@@ -67,6 +67,19 @@ public class MovePipeTest extends AbstractPipeTest {
         session.save();
         Assert.assertTrue("target node path should exist", session.nodeExists(PATH_FRUITS + BANANA_NODE_PATH));
         Assert.assertFalse("source node path should have gone", session.nodeExists(PATH_FRUITS + APPLE_NODE_PATH));
+    }
+
+    @Ignore //move operation is not supported yet by MockSession
+    @Test
+    public void testMoveNodeWithOrdering() throws Exception {
+        Iterator<Resource> output = getOutput(PATH_PIPE + MOVENODEORDER_PIPE);
+        Assert.assertTrue(output.hasNext());
+        output.next();
+        Session session = context.resourceResolver().adaptTo(Session.class);
+        session.save();
+        Assert.assertTrue("target node path should exist", session.nodeExists(PATH_FRUITS + BANANA_NODE_PATH));
+        Assert.assertTrue("source node path also should exist", session.nodeExists(PATH_FRUITS + APPLE_NODE_PATH));
+        Assert.assertEquals("difference in position should be 1", session.getNode(PATH_FRUITS + BANANA_NODE_PATH).getIndex() - session.getNode(PATH_FRUITS + APPLE_NODE_PATH).getIndex(), 1);
     }
 
     @Ignore //move operation is not supported yet by MockSession

--- a/src/test/resources/move.json
+++ b/src/test/resources/move.json
@@ -14,12 +14,12 @@
     "sling:resourceType":"slingPipes/mv",
     "path": "/content/fruits/apple",
     "expr": "/content/fruits/banana",
-    "overwrite": "true"
+    "overwriteTarget": true
   },
   "moveNodeOrder": {
     "sling:resourceType":"slingPipes/mv",
-    "path": "/content/fruits/apple",
-    "expr": "/content/fruits/banana",
-    "orderBeforeTarget": "true"
+    "path": "/content/fruits/banana",
+    "expr": "/content/fruits/apple",
+    "orderBeforeTarget": true
   }
 }

--- a/src/test/resources/move.json
+++ b/src/test/resources/move.json
@@ -15,5 +15,11 @@
     "path": "/content/fruits/apple",
     "expr": "/content/fruits/banana",
     "overwrite": "true"
+  },
+  "moveNodeOrder": {
+    "sling:resourceType":"slingPipes/mv",
+    "path": "/content/fruits/apple",
+    "expr": "/content/fruits/banana",
+    "orderBeforeTarget": "true"
   }
 }


### PR DESCRIPTION
Move pipe to incorporate ordering of the nodes .

usage ->
.echo("abc/xyz/def")
.mv("foo/bar").with("orderBeforeTarget",true)

will move def and its children under foo and place before bar...

@npeltier , please review ....