### PR TITLE
SLING-8648 Move pipe to incorporate ordering of the nodes .

### DIFF
--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -70,26 +70,28 @@ public class MovePipe extends BasePipe {
                 if (orderBefore) {
                     output = reorder(resource, targetPath, session);
                 } else if (session.itemExists(targetPath)) {
-                    if (overwriteTarget && !isDryRun()) {
-                        logger.debug("overwriting {}", targetPath);
-                        Resource parent = resolver.getResource(targetPath).getParent();
-                        Node targetParent = session.getItem(targetPath).getParent();
-                        if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
-                            String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
-                            String targetPathNewNode = targetPath + UUID.randomUUID();
-                            String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
-                            session.move(resource.getPath(), targetPathNewNode);
-                            targetParent.orderBefore(newNodeName, oldNodeName);
-                            session.removeItem(targetPath);
-                            // Need to use JackrabbitNode.rename() here, since session.move(targetPathNewNode, targetPath)
-                            // would move the new node back to the end of its siblings list
-                            JackrabbitNode newNode = (JackrabbitNode) session.getNode(targetPathNewNode);
-                            newNode.rename(oldNodeName);
-                            return Collections.singleton(parent.getChild(oldNodeName)).iterator();
-                        } else {
-                            session.removeItem(targetPath);
-                            session.move(resource.getPath(), targetPath);
-                            return Collections.singleton(parent.getChild(resource.getName())).iterator();
+                    if (overwriteTarget) {
+                        logger.info("overwriting {}", targetPath);
+                        if (!isDryRun()) {
+                            Resource parent = resolver.getResource(targetPath).getParent();
+                            Node targetParent = session.getItem(targetPath).getParent();
+                            if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
+                                String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
+                                String targetPathNewNode = targetPath + UUID.randomUUID();
+                                String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
+                                session.move(resource.getPath(), targetPathNewNode);
+                                targetParent.orderBefore(newNodeName, oldNodeName);
+                                session.removeItem(targetPath);
+                                // Need to use JackrabbitNode.rename() here, since session.move(targetPathNewNode, targetPath)
+                                // would move the new node back to the end of its siblings list
+                                JackrabbitNode newNode = (JackrabbitNode) session.getNode(targetPathNewNode);
+                                newNode.rename(oldNodeName);
+                                return Collections.singleton(parent.getChild(oldNodeName)).iterator();
+                            } else {
+                                session.removeItem(targetPath);
+                                session.move(resource.getPath(), targetPath);
+                                return Collections.singleton(parent.getChild(resource.getName())).iterator();
+                            }
                         }
                     } else {
                         logger.warn("{} already exists, nothing will be done here, nothing outputed");
@@ -128,7 +130,7 @@ public class MovePipe extends BasePipe {
     }
 
     private Iterator<Resource> reorder(Resource resource, String targetPath, Session session) throws Exception {
-        logger.debug("ordering {} before {}", resource.getPath(), targetPath);
+        logger.info("ordering {} before {}", resource.getPath(), targetPath);
         if (session.itemExists(targetPath) && !isDryRun()) {
             Resource parent = resolver.getResource(targetPath).getParent();
             Node targetParent = session.getItem(targetPath).getParent();

--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -69,8 +69,7 @@ public class MovePipe extends BasePipe {
                 Session session = resolver.adaptTo(Session.class);
                 if (orderBefore) {
                     output = reorder(resource, targetPath, session);
-                }
-                if (session.itemExists(targetPath)){
+                } else if (session.itemExists(targetPath)) {
                     if (overwriteTarget && !isDryRun()) {
                         logger.debug("overwriting {}", targetPath);
                         Resource parent = resolver.getResource(targetPath).getParent();

--- a/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/MovePipe.java
@@ -75,10 +75,10 @@ public class MovePipe extends BasePipe {
                         logger.debug("overwriting {}", targetPath);
                         Resource parent = resolver.getResource(targetPath).getParent();
                         Node targetParent = session.getItem(targetPath).getParent();
-                        String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
-                        String targetPathNewNode = targetPath + UUID.randomUUID();
-                        String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
                         if (targetParent.getPrimaryNodeType().hasOrderableChildNodes()) {
+                            String oldNodeName = targetPath.substring(targetPath.lastIndexOf("/") + 1);
+                            String targetPathNewNode = targetPath + UUID.randomUUID();
+                            String newNodeName = targetPathNewNode.substring(targetPathNewNode.lastIndexOf("/") + 1);
                             session.move(resource.getPath(), targetPathNewNode);
                             targetParent.orderBefore(newNodeName, oldNodeName);
                             session.removeItem(targetPath);

--- a/src/test/java/org/apache/sling/pipes/internal/MovePipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/MovePipeTest.java
@@ -16,16 +16,21 @@
  */
 package org.apache.sling.pipes.internal;
 
+import org.apache.commons.collections.IteratorUtils;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.pipes.AbstractPipeTest;
+import org.apache.sling.pipes.Pipe;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.jcr.Session;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * testing moving nodes & properties
@@ -34,50 +39,71 @@ public class MovePipeTest extends AbstractPipeTest {
 
     static final String MOVENODE_PIPE = "/moveNode";
     static final String MOVENODEOVERWRITE_PIPE = "/moveNodeOverwrite";
+    static final String MOVENODEORDER_PIPE = "/moveNodeOrder";
     static final String MOVEPROPERTY_PIPE = "/moveProperty";
     static final String APPLE_NODE_PATH = "/apple";
     static final String BANANA_NODE_PATH = "/banana";
     static final String MOVED_NODE_PATH = "/granny";
-    static final String MOVED_PROPERTY_PATH = "/indexFruits";
+    static final String MOVED_PROPERTY_PATH = "/fruitsIndex";
+
+    @Rule
+    public SlingContext oak = new SlingContext(ResourceResolverType.JCR_OAK);
 
     @Before
     public void setup() throws PersistenceException {
         super.setup();
-        context.load().json("/move.json", PATH_PIPE);
+        oak.load().json("/move.json", PATH_PIPE);
+        oak.load().json("/SLING-INF/jcr_root/content/fruits.json", PATH_FRUITS);
     }
 
-    @Ignore //move operation is not supported yet by MockSession
     @Test
     public void testMoveNode() throws Exception {
-        Iterator<Resource> output = getOutput(PATH_PIPE + MOVENODE_PIPE);
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + MOVENODE_PIPE));
+        Iterator<Resource> output = pipe.getOutput();
         Assert.assertTrue(output.hasNext());
         output.next();
-        Session session = context.resourceResolver().adaptTo(Session.class);
+        Session session = oak.resourceResolver().adaptTo(Session.class);
         session.save();
         Assert.assertTrue("new node path should exists", session.nodeExists(PATH_FRUITS + MOVED_NODE_PATH));
     }
 
-    @Ignore //move operation is not supported yet by MockSession
     @Test
     public void testMoveNodeWithOverwrite() throws Exception {
-        Iterator<Resource> output = getOutput(PATH_PIPE + MOVENODEOVERWRITE_PIPE);
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + MOVENODEOVERWRITE_PIPE));
+        Iterator<Resource> output = pipe.getOutput();
         Assert.assertTrue(output.hasNext());
         output.next();
-        Session session = context.resourceResolver().adaptTo(Session.class);
+        Session session = oak.resourceResolver().adaptTo(Session.class);
         session.save();
         Assert.assertTrue("target node path should exist", session.nodeExists(PATH_FRUITS + BANANA_NODE_PATH));
         Assert.assertFalse("source node path should have gone", session.nodeExists(PATH_FRUITS + APPLE_NODE_PATH));
     }
 
-    @Ignore //move operation is not supported yet by MockSession
+    @Test
+    public void testMoveNodeWithOrdering() throws Exception {
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + MOVENODEORDER_PIPE));
+        Iterator<Resource> output = pipe.getOutput();
+        Assert.assertTrue(output.hasNext());
+        Resource resource = output.next();
+        Resource parent = resource.getParent();
+        List<Resource> allFruits = IteratorUtils.toList(parent.listChildren());
+        Session session = oak.resourceResolver().adaptTo(Session.class);
+        session.save();
+        Assert.assertTrue("target node path should exist", session.nodeExists(PATH_FRUITS + APPLE_NODE_PATH));
+        Assert.assertTrue("source node path also should exist", session.nodeExists(resource.getPath()));
+        Assert.assertEquals("banana should be at first position", allFruits.get(0).getName(), resource.getName());
+        Assert.assertEquals("apple should be at first position", allFruits.get(1).getName(), "apple");
+    }
+
     @Test
     public void testMoveProperty() throws Exception {
-        Iterator<Resource> output = getOutput(PATH_PIPE + MOVEPROPERTY_PIPE);
+        Pipe pipe = plumber.getPipe(oak.resourceResolver().getResource(PATH_PIPE + MOVEPROPERTY_PIPE));
+        Iterator<Resource> output = pipe.getOutput();
         Assert.assertTrue(output.hasNext());
         output.next();
-        Session session = context.resourceResolver().adaptTo(Session.class);
+        Session session = oak.resourceResolver().adaptTo(Session.class);
         session.save();
-        Assert.assertTrue("new property path should exists", session.propertyExists(PATH_FRUITS + MOVED_NODE_PATH));
+        Assert.assertTrue("new property path should exists", session.propertyExists(PATH_FRUITS + MOVED_PROPERTY_PATH));
         Assert.assertFalse("old property path should not", session.propertyExists(PATH_FRUITS + PN_INDEX));
     }
 }

--- a/src/test/resources/move.json
+++ b/src/test/resources/move.json
@@ -14,6 +14,12 @@
     "sling:resourceType":"slingPipes/mv",
     "path": "/content/fruits/apple",
     "expr": "/content/fruits/banana",
-    "overwrite": "true"
+    "overwriteTarget": true
+  },
+  "moveNodeOrder": {
+    "sling:resourceType":"slingPipes/mv",
+    "path": "/content/fruits/banana",
+    "expr": "/content/fruits/apple",
+    "orderBeforeTarget": true
   }
 }


### PR DESCRIPTION
usage ->
.echo("abc/xyz/def")
.mv("foo/bar").with("orderBeforeTarget",true)

will move def and its children under foo and place before bar...

@npeltier , please review ....