### PR TITLE
SLING-10848  & SLING-10847 - RegexPipe enhancements

### DIFF
--- a/src/main/java/org/apache/sling/pipes/AbstractInputStreamPipe.java
+++ b/src/main/java/org/apache/sling/pipes/AbstractInputStreamPipe.java
@@ -51,6 +51,9 @@ public abstract class AbstractInputStreamPipe extends BasePipe {
     private static final String AUTH_HEADER = "Authentication";
 
     private static final String BASIC_PREFIX = "Basic ";
+    private static final String PN_URL_MODE = "url_mode";
+    private static final String URL_MODE_FETCH = "FETCH";
+    private static final String URL_MODE_AS_IS = "AS_IS";
 
     protected Object binding;
 
@@ -71,7 +74,7 @@ public abstract class AbstractInputStreamPipe extends BasePipe {
 
     InputStream getInputStream() throws IOException {
         String expr = getExpr();
-        if (expr.startsWith(REMOTE_START)) {
+        if (expr.startsWith(REMOTE_START) && !properties.get(PN_URL_MODE, URL_MODE_FETCH).equalsIgnoreCase(URL_MODE_AS_IS)) {
             //first look at
             String urlExpression = getExpr();
             if (StringUtils.isNotBlank(urlExpression)) {

--- a/src/main/java/org/apache/sling/pipes/internal/inputstream/RegexpPipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/inputstream/RegexpPipe.java
@@ -56,6 +56,10 @@ public class RegexpPipe extends AbstractInputStreamPipe {
         Iterator<Resource> output = EMPTY_ITERATOR;
         try {
             String patternString = bindings.instantiateExpression(properties.get(PN_PATTERN, String.class));
+            if (patternString == null){
+                logger.debug("pattern {} evaluates as empty.", properties.get(PN_PATTERN, String.class));
+                return output;
+            }
             final Collection<String> names = getGroupNames(patternString);
             if (names.isEmpty()){
                 logger.debug("no name defined, will take the whole match");

--- a/src/main/java/org/apache/sling/pipes/internal/inputstream/RegexpPipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/inputstream/RegexpPipe.java
@@ -55,7 +55,7 @@ public class RegexpPipe extends AbstractInputStreamPipe {
     public Iterator<Resource> getOutput(InputStream inputStream) {
         Iterator<Resource> output = EMPTY_ITERATOR;
         try {
-            String patternString = properties.get(PN_PATTERN, String.class);
+            String patternString = bindings.instantiateExpression(properties.get(PN_PATTERN, String.class));
             final Collection<String> names = getGroupNames(patternString);
             if (names.isEmpty()){
                 logger.debug("no name defined, will take the whole match");
@@ -111,4 +111,6 @@ public class RegexpPipe extends AbstractInputStreamPipe {
         }
         return names;
     }
+
+
 }

--- a/src/test/java/org/apache/sling/pipes/internal/inputstream/RegexpPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/inputstream/RegexpPipeTest.java
@@ -80,4 +80,17 @@ public class RegexpPipeTest extends AbstractPipeTest {
         assertEquals("one created resource's domain should be somesite", "http://somesite.com",
                 context.resourceResolver().getResource("/content/img/1.png/domain").adaptTo(String.class));
     }
+
+    @Test
+    public void testRegexAsIsUrl() throws Exception {
+        Pipe pipe = plumber.newPipe(context.resourceResolver())
+                .echo("/content")
+                .egrep("https://sling.apache.org/documentation/bundles/sling-pipes/readers.html")
+                .name("result").with("pattern","(?<domain>https?://[^/]+)(?<uri>[^\"^\']+)")
+                .with("url_mode","as_is").build();
+        Iterator<Resource> output = pipe.getOutput();
+        IteratorUtils.toList(output);
+        assertEquals("domain should be read from the egrep expression as is", "https://sling.apache.org",pipe.getBindings().instantiateExpression("${result.domain}"));
+        assertEquals("uri should be read from the egrep expression as is", "/documentation/bundles/sling-pipes/readers.html",pipe.getBindings().instantiateExpression("${result.uri}"));
+    }
 }


### PR DESCRIPTION
RegexPipe enhancements:
- read the pattern from bindings if available 
- implement "url_mode" property to enable treating urls as a String for RegexPipes

