### PR TITLE
SLING-11041 - closing the InputStream 

### DIFF
--- a/src/main/java/org/apache/sling/pipes/AbstractInputStreamPipe.java
+++ b/src/main/java/org/apache/sling/pipes/AbstractInputStreamPipe.java
@@ -117,8 +117,12 @@ public abstract class AbstractInputStreamPipe extends BasePipe {
             return getOutput(is);
         }  catch (IOException e) {
             throw new IllegalArgumentException(e);
-        } finally {
-            IOUtils.closeQuietly(is);
         }
+    }
+
+    @Override
+    public void after() {
+        super.after();
+        IOUtils.closeQuietly(is);
     }
 }

--- a/src/test/java/org/apache/sling/pipes/AbstractPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/AbstractPipeTest.java
@@ -63,6 +63,9 @@ public class AbstractPipeTest {
     protected static final String NN_COMPLEX = "complex";
     protected static final String PN_INDEX = "/index";
 
+    protected static final int PORT = 1234;
+    protected static final String baseUrl = "http://127.0.0.1:" + PORT;
+
     protected Plumber plumber;
 
     protected CommandExecutor commandsExecutor;

--- a/src/test/java/org/apache/sling/pipes/internal/inputstream/CsvPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/inputstream/CsvPipeTest.java
@@ -16,22 +16,31 @@
  */
 package org.apache.sling.pipes.internal.inputstream;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.pipes.AbstractPipeTest;
+import org.apache.sling.pipes.ExecutionResult;
 import org.apache.sling.pipes.Pipe;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.Assert.assertEquals;
 
 /**
  * testing csv pipe
  */
-public class CsvPipeTest extends AbstractPipeTest{
+public class CsvPipeTest extends AbstractPipeTest {
+
+    @Rule
+    public WireMockRule http = new WireMockRule(PORT);
 
     @Test
     public void getOutput() throws Exception {
@@ -42,10 +51,20 @@ public class CsvPipeTest extends AbstractPipeTest{
                 .mkdir(PATH_FRUITS + "/csv/${csv.fruit}-${csv.color}-${csv.id}").build();
         Iterator<Resource> output = pipe.getOutput();
         List<Resource> resources = IteratorUtils.toList(output);
-        List<String> paths = resources.stream().map( resource -> resource.getPath()).collect(Collectors.toList());
+        List<String> paths = resources.stream().map(resource -> resource.getPath()).collect(Collectors.toList());
         assertEquals("there should be 3 elements", 3, paths.size());
         assertEquals("first should be /content/fruits/csv/apple-green-1", "/content/fruits/csv/apple-green-1", paths.get(0));
         assertEquals("second should be /content/fruits/csv/banana-yellow-2", "/content/fruits/csv/banana-yellow-2", paths.get(1));
         assertEquals("first should be /content/fruits/csv/plum-purple-3", "/content/fruits/csv/plum-purple-3", paths.get(2));
+    }
+
+    @Test
+    public void testCsvInputStream() throws IllegalAccessException {
+        http.givenThat(get(urlEqualTo("/get/standardTest.csv"))
+                .willReturn(aResponse().withStatus(200).withBodyFile("standardTest.csv")));
+        ExecutionResult results = plumber.newPipe(context.resourceResolver())
+                .csv(baseUrl + "/get/standardTest.csv").name("item").mkdir("/home/${item.fruit}").run();
+        assertEquals(3, results.size());
+        assertEquals("{\"items\":[\"/home/apple\",\"/home/banana\",\"/home/plum\"],\"size\":3}", results.toString());
     }
 }

--- a/src/test/java/org/apache/sling/pipes/internal/inputstream/JsonPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/inputstream/JsonPipeTest.java
@@ -54,9 +54,6 @@ public class JsonPipeTest extends AbstractPipeTest {
         context.load().json("/json.json", "/content/json");
     }
 
-    private static final int PORT = 1234;
-    private static final String baseUrl = "http://127.0.0.1:" + PORT;
-
     @Rule
     public WireMockRule http = new WireMockRule(PORT);
 

--- a/src/test/resources/__files/standardTest.csv
+++ b/src/test/resources/__files/standardTest.csv
@@ -1,0 +1,4 @@
+fruit,color,id
+apple,green,1
+banana,yellow,2
+plum,purple,3


### PR DESCRIPTION
SLING-11041 - closing the InputStream in the after hook instead in the finally block