### PR TITLE
SLING-13120 Pipes: Make compatible with Java 17/21

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -19,7 +19,8 @@ Sling-Model-Packages:\
 
 -includeresource:\
   @org.apache.sling.jcr.contentparser-*.jar!/org/apache/sling/jcr/contentparser/impl/JsonTicksConverter.*,\
-  @target/dependency/commons-jexl3-3.0.jar
+  @target/dependency/commons-jexl3-3.0.jar,\
+  @target/dependency/nashorn-core-15.7.jar
 
 -removeheaders:\
   Include-Resource,\

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
+      <version>1.22.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -424,7 +424,7 @@
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
       <scope>test</scope>
-      <version>1.4.0</version>
+      <version>1.5.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.outputTimestamp>1660725790</project.build.outputTimestamp>
     <sling.java.version>11</sling.java.version>
-    <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
+    <org.ops4j.pax.exam.version>4.14.0</org.ops4j.pax.exam.version>
     <oak.version>1.68.0</oak.version>
     <jackrabbit.version>2.22.2</jackrabbit.version>
   </properties>
@@ -375,7 +375,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.paxexam</artifactId>
-      <version>3.1.0</version>
+      <version>4.1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -399,7 +399,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>6.0.3</version>
+      <version>7.0.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
     <project.build.outputTimestamp>1660725790</project.build.outputTimestamp>
     <sling.java.version>11</sling.java.version>
     <org.ops4j.pax.exam.version>4.14.0</org.ops4j.pax.exam.version>
-    <oak.version>1.68.0</oak.version>
-    <jackrabbit.version>2.22.2</jackrabbit.version>
+    <oak.version>1.48.0</oak.version>
+    <jackrabbit.version>2.20.8</jackrabbit.version>
   </properties>
 
   <scm>
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.27.6</version>
+      <version>2.25.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <includeArtifactIds>commons-jexl3</includeArtifactIds>
+              <includeArtifactIds>commons-jexl3,nashorn-core</includeArtifactIds>
             </configuration>
           </execution>
         </executions>
@@ -267,15 +267,21 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.caconfig.api</artifactId>
       <version>1.1.2</version>
-      <groupId>org.apache.sling</groupId>
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.caconfig.spi</artifactId>
       <version>1.3.4</version>
-      <groupId>org.apache.sling</groupId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,11 @@
   <description>bulk content changes tool</description>
 
   <properties>
+    <project.build.outputTimestamp>1660725790</project.build.outputTimestamp>
     <sling.java.version>11</sling.java.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
-    <project.build.outputTimestamp>1660725790</project.build.outputTimestamp>
+    <oak.version>1.68.0</oak.version>
+    <jackrabbit.version>2.22.2</jackrabbit.version>
   </properties>
 
   <scm>
@@ -85,6 +87,16 @@
             <exclude>src/test/resources/**/*.csv</exclude>
             <exclude>src/test/resources/OSGI-INF/*.xml</exclude>
           </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- nashorn-core has a module-info.class, causing Surefire to place it on the module path.
+               This makes the JVM enforce JPMS access rules, which blocks the reflective field injection
+               used by the Sling OSGi mock framework. Force classpath mode to avoid this. -->
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
     </plugins>
@@ -180,7 +192,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.16.0</version>
+      <version>2.27.6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -191,13 +203,13 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.query</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-api</artifactId>
-      <version>2.14.0</version>
+      <artifactId>oak-jackrabbit-api</artifactId>
+      <version>${oak.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -233,7 +245,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.jcr.resource</artifactId>
-      <version>2.7.4</version>
+      <version>3.0.18</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -245,19 +257,19 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.models.api</artifactId>
-      <version>1.3.2</version>
+      <version>1.3.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit.vault</groupId>
       <artifactId>org.apache.jackrabbit.vault</artifactId>
-      <version>3.1.44</version>
+      <version>3.2.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-jcr-commons</artifactId>
-      <version>2.14.0</version>
+      <version>${jackrabbit.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -309,19 +321,13 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-      <version>2.6.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
-      <version>1.3.2</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-      <version>2.1.0</version>
+      <version>4.0.0-1.62.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,9 @@
   <description>bulk content changes tool</description>
 
   <properties>
-    <sling.java.version>8</sling.java.version>
+    <sling.java.version>11</sling.java.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
     <project.build.outputTimestamp>1660725790</project.build.outputTimestamp>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
   <scm>
@@ -157,6 +155,12 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -291,10 +295,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.21.0</version>
+        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/pipes/internal/PathPipe.java
+++ b/src/main/java/org/apache/sling/pipes/internal/PathPipe.java
@@ -16,6 +16,14 @@
  */
 package org.apache.sling.pipes.internal;
 
+import static org.apache.sling.jcr.resource.api.JcrResourceConstants.NT_SLING_FOLDER;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.sling.api.resource.PersistenceException;
@@ -26,13 +34,6 @@ import org.apache.sling.pipes.PipeBindings;
 import org.apache.sling.pipes.Plumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import java.util.Collections;
-import java.util.Iterator;
-
-import static org.apache.sling.jcr.resource.JcrResourceConstants.NT_SLING_FOLDER;
 
 /**
  * creates or get given expression's path and returns corresponding resource

--- a/src/main/java/org/apache/sling/pipes/internal/PipeBuilderImpl.java
+++ b/src/main/java/org/apache/sling/pipes/internal/PipeBuilderImpl.java
@@ -16,6 +16,21 @@
  */
 package org.apache.sling.pipes.internal;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.sling.jcr.resource.api.JcrResourceConstants.NT_SLING_FOLDER;
+import static org.apache.sling.jcr.resource.api.JcrResourceConstants.NT_SLING_ORDERED_FOLDER;
+import static org.apache.sling.jcr.resource.api.JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY;
+import static org.apache.sling.pipes.BasePipe.SLASH;
+import static org.apache.sling.pipes.CommandUtil.checkArguments;
+import static org.apache.sling.pipes.CommandUtil.writeToMap;
+import static org.apache.sling.pipes.internal.ManifoldPipe.PN_NUM_THREADS;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
@@ -42,21 +57,6 @@ import org.apache.sling.pipes.internal.slingquery.ParentsPipe;
 import org.apache.sling.pipes.internal.slingquery.SiblingsPipe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.sling.jcr.resource.JcrResourceConstants.NT_SLING_FOLDER;
-import static org.apache.sling.jcr.resource.JcrResourceConstants.NT_SLING_ORDERED_FOLDER;
-import static org.apache.sling.jcr.resource.JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY;
-import static org.apache.sling.pipes.BasePipe.SLASH;
-import static org.apache.sling.pipes.CommandUtil.checkArguments;
-import static org.apache.sling.pipes.CommandUtil.writeToMap;
-import static org.apache.sling.pipes.internal.ManifoldPipe.PN_NUM_THREADS;
 /**
  * Implementation of the PipeBuilder interface
  */

--- a/src/test/java/org/apache/sling/pipes/internal/PathPipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/PathPipeTest.java
@@ -16,17 +16,7 @@
  */
 package org.apache.sling.pipes.internal;
 
-import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.pipes.AbstractPipeTest;
-import org.apache.sling.pipes.Pipe;
-import org.junit.Test;
-
-import javax.jcr.Node;
-
-import static org.apache.sling.jcr.resource.JcrResourceConstants.NT_SLING_FOLDER;
+import static org.apache.sling.jcr.resource.api.JcrResourceConstants.NT_SLING_FOLDER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -34,6 +24,16 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
 import java.util.Calendar;
+
+import javax.jcr.Node;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.pipes.AbstractPipeTest;
+import org.apache.sling.pipes.Pipe;
+import org.junit.Test;
 
 /**
  * Testing path pipe using pipe builder
@@ -93,5 +93,5 @@ public class PathPipeTest extends AbstractPipeTest {
         Instant modifiedAgain = Instant.ofEpochMilli(fruits.get("jcr:lastModified", Calendar.class).getTimeInMillis());
         assertEquals("path should not mark *again* a path already created", modified, modifiedAgain);
     }
-    
+
 }

--- a/src/test/java/org/apache/sling/pipes/internal/TraversePipeTest.java
+++ b/src/test/java/org/apache/sling/pipes/internal/TraversePipeTest.java
@@ -16,6 +16,15 @@
  */
 package org.apache.sling.pipes.internal;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
@@ -23,15 +32,6 @@ import org.apache.sling.pipes.AbstractPipeTest;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.cglib.core.CollectionUtils;
-
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Testing traverse pipes and its different configurations on the same resource tree
@@ -40,6 +40,7 @@ public class TraversePipeTest extends AbstractPipeTest {
     public static final String ROOT = "/content/traverse";
     public static final String CONF_ROOT = ROOT + "/pipes/";
 
+    @Override
     @Before
     public void setup() throws PersistenceException {
         super.setup();
@@ -74,7 +75,7 @@ public class TraversePipeTest extends AbstractPipeTest {
     @Test
     @Ignore //for now nameGlobs is not implemented (see SLING-7089)
     public void testWhiteListProperties() throws Exception {
-        List<String> colorList = CollectionUtils.transform(getResourceList("whiteListProperties"), o -> ((Resource)o).adaptTo(String.class));
+        List<String> colorList = getResourceList("whiteListProperties").stream().map(o -> o.adaptTo(String.class)).collect(Collectors.toList());
         assertListEquals(colorList, "green", "yellow", "green", "orange");
     }
 
@@ -88,7 +89,7 @@ public class TraversePipeTest extends AbstractPipeTest {
         return IteratorUtils.toList(output);
     }
     List<String> getResourceNameList(String pipeName){
-        return CollectionUtils.transform(getResourceList(pipeName), o -> ((Resource)o).getName());
+        return getResourceList(pipeName).stream().map(o -> o.getName()).collect(Collectors.toList());
     }
 
     private void assertListEquals(List<String> tested, String... expected){

--- a/src/test/java/org/apache/sling/pipes/it/PipesTestSupport.java
+++ b/src/test/java/org/apache/sling/pipes/it/PipesTestSupport.java
@@ -18,6 +18,22 @@
  */
 package org.apache.sling.pipes.it;
 
+import static org.apache.sling.testing.paxexam.SlingOptions.slingCaconfig;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingCommonsHtml;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingDistribution;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingEvent;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingQuery;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingResourcePresence;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingHtl;
+import static org.apache.sling.testing.paxexam.SlingOptions.versionResolver;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.factoryConfiguration;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
+
 import javax.inject.Inject;
 import javax.servlet.Servlet;
 
@@ -34,22 +50,6 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.ProbeBuilder;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.util.Filter;
-
-import static org.apache.sling.testing.paxexam.SlingOptions.slingCaconfig;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingCommonsHtml;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingDistribution;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingEvent;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingQuery;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingResourcePresence;
-import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingSightly;
-import static org.apache.sling.testing.paxexam.SlingOptions.versionResolver;
-import static org.ops4j.pax.exam.CoreOptions.composite;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.factoryConfiguration;
-import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 
 public abstract class PipesTestSupport extends TestSupport {
 
@@ -88,7 +88,8 @@ public abstract class PipesTestSupport extends TestSupport {
             factoryConfiguration("org.apache.sling.resource.presence.internal.ResourcePresenter")
                 .put("path", "/etc/pipes-it/fruit-list")
                 .asOption(),
-            mavenBundle().groupId("org.apache.geronimo.bundles").artifactId("commons-httpclient").version(versionResolver),
+             // TODO: still required?
+            // mavenBundle().groupId("org.apache.geronimo.bundles").artifactId("commons-httpclient").version(versionResolver),
             // testing
             slingResourcePresence(),
             slingCaconfig(),
@@ -121,7 +122,7 @@ public abstract class PipesTestSupport extends TestSupport {
             slingDistribution(),
             slingQuery(),
             slingCommonsHtml(),
-            slingScriptingSightly()
+            slingScriptingHtl()
         );
     }
 


### PR DESCRIPTION
this is an uncompleted draft PR. the pax exam tests are still failing with some unresolved dependencies.

so far, it contains:
* embed nashorn scripting engine (not sure if it works that way already in the bundle deployed to OSGi, the module-info makes it tricky)
* updated most of the testing dependencies including pax-exam
* updated a couple of other dependencies to make it compatible with the version included in pax-exam
